### PR TITLE
#41 : Ajoute le filtre 'alignments' dans Gloses.yaml

### DIFF
--- a/examples/data/Gloses.yaml
+++ b/examples/data/Gloses.yaml
@@ -8,8 +8,15 @@ source: # Français
 destination: # Kalaba
   D:
     Genre: [ m, f, n ]
-    Nombre: [ sg, pl ]
+    Nombre: [ sg, du, pl ]
   NOM:
     Cf: [ n1, n2 ]
     Genre: [ m, f, n ]
-    Nombre: [ sg, pl ]
+    Nombre: [ sg, du, pl ]
+alignments:
+  D:
+    Nombre=sg: [ Nombre=sg ]
+    Nombre=pl: [ Nombre=du, Nombre=pl ]
+  NOM:
+    Nombre=sg: [ Nombre=sg ]
+    Nombre=pl: [ Nombre=du, Nombre=pl ]

--- a/pfmg/lexique/glose/CGloses.py
+++ b/pfmg/lexique/glose/CGloses.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2024, Korantin Lévêque <korantin.leveque@protonmail.com>
+# All rights reserved.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Gloses avec contraintes."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from frozendict import frozendict
+
+from pfmg.external.reader.ABCReader import ABCReader
+from pfmg.lexique.glose.Gloses import Gloses
+from pfmg.lexique.glose.Sigma import Sigma
+from pfmg.lexique.glose.Sigmas import Sigmas
+from pfmg.parsing.features.utils import FeatureReader
+
+
+@dataclass
+class CGloses(ABCReader):
+    """Gloses avec contraintes.
+
+    Args:
+    ----
+        gloses: Les gloses standards d'un paradigme
+        alignments: Contraintes appliquées sur le paradigme
+                    entre source et destination
+
+    Examples:
+    --------
+        Les contraintes permettent de valider l'exemple suivant.
+        si le Nombre de source est 'sg' alors le Nombre de destination est 'sg'.
+        De ce fait,
+        si le Nombre de source est 'sg' et que le Nombre de destination est 'pl'
+        alors cette configuration de Sigma ne sera pas retenue.
+
+    """
+
+    gloses: Gloses
+    alignments: Gloses
+
+    def __call__(self, pos: str) -> list:
+        """Apply the normal Gloses and filter it with alignments.
+
+        :param pos: Some POS value
+        :return: the filtered list of sigmas
+        """
+        result = []
+        for x in self.gloses(pos):
+            if x in self.alignments(pos):
+                result.append(x)
+        return result
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "CGloses":
+        """Construit un CGloses depuis un fichier YAML.
+
+        :param path: Chemin vers le fichier YAML
+        :return: Une CGloses valide prête à l'emploi
+        """
+        with open(path, encoding="utf8") as fh:
+            data = yaml.safe_load(fh)
+        gloses = Gloses.from_dict(data)
+        alignments = Gloses(cls.__read_alignments(data["alignments"]))
+        return cls(gloses=gloses, alignments=alignments)
+
+    @staticmethod
+    def __read_alignments(data: dict[str, dict[str, list[str]]]) -> dict:
+        """Méthode privée qui lit et met enforme les alignements.
+
+        :param data: l'entrée 'alignments' du fichier YAML.
+        :return: la structure de données correctement formattée pour Gloses
+        """
+        fr = FeatureReader()
+        output: dict[str, Sigmas] = {}
+        for pos, sigmas in data.items():
+            _tmp: list[Sigma] = []
+            for key, value in sigmas.items():
+                for val in value:
+                    _tmp.append(
+                        Sigma(
+                            source=frozendict(fr.parse(key)[0]),
+                            destination=frozendict(fr.parse(val)[0]),
+                        )
+                    )
+            output[pos] = Sigmas(_tmp)
+        return output

--- a/pfmg/lexique/glose/Sigma.py
+++ b/pfmg/lexique/glose/Sigma.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2024, Korantin Lévêque <korantin.leveque@protonmail.com>
+# All rights reserved.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Informations morphosyntaxiques d'une Forme."""
+
+from dataclasses import dataclass
+
+from frozendict import frozendict
+
+
+@dataclass
+class Sigma:
+    """Informations morphosyntaxiques d'une Forme.
+
+    Args:
+    ----
+        source: Dictionnaire non éditable
+        destination: Dictionnaire non éditable
+
+    """
+
+    source: frozendict[str, str]
+    destination: frozendict[str, str]
+
+    def __le__(self, other: "Sigma") -> bool:
+        """Vérifie si les clés/valeurs de other.source sont dans self.source.
+
+        :param other: un autre Sigma
+        :return: True si les clés/valeurs de other.source sont dans self.source
+        """
+        return (self.source.items() <= other.source.items()) and (
+            self.destination.items() <= other.destination.items()
+        )

--- a/pfmg/lexique/glose/Sigmas.py
+++ b/pfmg/lexique/glose/Sigmas.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2024, Korantin Lévêque <korantin.leveque@protonmail.com>
+# All rights reserved.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Ensemble de Sigma."""
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from pfmg.lexique.glose.Sigma import Sigma
+
+
+@dataclass
+class Sigmas:
+    """Ensemble de Sigma."""
+
+    data: list[Sigma]
+
+    def __contains__(self, item: Sigma) -> bool:
+        """TODO Doc à écrire.
+
+        :param item:
+        :return:
+        """
+        for x in self.data:
+            if x <= item:
+                return True
+        return False
+
+    def __iter__(self) -> Iterator[Sigma]:
+        """Itérateur de Sigma.
+
+        :return: un itérateur de Sigma
+        """
+        return iter(self.data)

--- a/pfmg/lexique/glose/__init__.py
+++ b/pfmg/lexique/glose/__init__.py
@@ -3,3 +3,31 @@
 
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+"""Default Factory de Gloses."""
+from pathlib import Path
+
+from pfmg.utils.abstract_factory import factory_class
+
+
+def new_gloses(path: Path):
+    """Constructeur de Gloses.
+
+    :param path: Chemin du fichier YAML
+    :return: Gloses ou CGloses
+    """
+    assert __package__ is not None
+
+    for name in ("CGloses", "Gloses"):
+        try:
+            result = factory_class(
+                concrete_product=name,
+                package=__package__
+            ).from_yaml(
+                path=path
+            )
+        except KeyError:
+            continue
+        else:
+            return result
+    else:
+        raise NameError

--- a/pfmg/lexique/paradigm/Paradigm.py
+++ b/pfmg/lexique/paradigm/Paradigm.py
@@ -13,7 +13,9 @@ from pfmg.external.reader.ABCReader import ABCReader
 from pfmg.lexique.block.Blocks import Blocks
 from pfmg.lexique.forme.Forme import Forme
 from pfmg.lexique.forme.FormeEntry import FormeEntry
+from pfmg.lexique.glose import new_gloses
 from pfmg.lexique.glose.Gloses import Gloses
+from pfmg.lexique.glose.Sigma import Sigma
 from pfmg.lexique.lexeme.Lexeme import Lexeme
 from pfmg.lexique.morpheme.Morphemes import Morphemes
 from pfmg.lexique.realizable.ABCRealizable import ABCRealizable
@@ -33,37 +35,29 @@ class Paradigm(ABCRealizable, ABCReader):
         :return: Liste des réalisations du lexème.
         """
         gloses = self.gloses(lexeme.source.pos)
-        source_sigma_items = lexeme.source.sigma.items()
-        destination_sigma_items = lexeme.destination.sigma.items()
         lexeme_pos = lexeme.source.pos
         for i_sigma in gloses:
-            i_sigma_source = i_sigma["source"]
-            i_sigma_destination = i_sigma["destination"]
-            source_validation = source_sigma_items <= i_sigma_source.items()
-            destination_validation = (
-                destination_sigma_items <= i_sigma_destination.items()
-            )
-            if source_validation and destination_validation:
+            if Sigma(lexeme.source.sigma, lexeme.destination.sigma) <= i_sigma:
                 yield Forme(
                     source=FormeEntry(
                         pos=lexeme_pos,
-                        sigma=i_sigma_source,
+                        sigma=i_sigma.source,
                         morphemes=Morphemes(
                             radical=lexeme.source.to_radical(),
                             others=self.blocks.source(
                                 pos=lexeme_pos,
-                                sigma=i_sigma_source,
+                                sigma=i_sigma.source,
                             ),
                         ),
                     ),
                     destination=FormeEntry(
                         pos=lexeme_pos,
-                        sigma=i_sigma_destination,
+                        sigma=i_sigma.destination,
                         morphemes=Morphemes(
                             radical=lexeme.destination.to_radical(),
                             others=self.blocks.destination(
                                 pos=lexeme_pos,
-                                sigma=i_sigma_destination,
+                                sigma=i_sigma.destination,
                             ),
                         ),
                     ),
@@ -78,7 +72,7 @@ class Paradigm(ABCRealizable, ABCReader):
         """
         assert (path / "Gloses.yaml").exists()
         return cls(
-            gloses=Gloses.from_yaml(
+            gloses=new_gloses(
                 path=path / "Gloses.yaml",
             ),
             blocks=Blocks.from_yaml(

--- a/pfmg/lexique/utils.py
+++ b/pfmg/lexique/utils.py
@@ -6,8 +6,12 @@
 """Différents utilitaires."""
 
 from ast import literal_eval
+from itertools import product
+from typing import overload
 
 from frozendict import frozendict
+
+from pfmg.utils.abstract_factory import factory_function
 
 
 def dictify(chars: str) -> frozendict:
@@ -26,3 +30,58 @@ def dictify(chars: str) -> frozendict:
             )
         ),
     )
+
+
+def gridify_dict(grid: dict[str, list[str]]) -> list[frozendict]:
+    """Produit cartésien sur les Traits d'une langue.
+
+    :param grid: Grille de paramètres
+    :return: liste de sigmas
+    """
+    assert isinstance(grid, dict)
+    assert grid
+
+    result = []
+
+    keys, values = zip(*sorted(grid.items()), strict=True)
+    for value in product(*values):
+        assert value
+        result.append(frozendict([*zip(keys, value, strict=True)]))
+
+    assert result
+    return result
+
+
+def gridify_list(grid: list) -> list[list[frozendict]]:
+    """Produit cartésien sur les Traits d'une langue.
+
+    :param grid: Grille de paramètres
+    :return: liste imbriquée de sigmas
+    """
+    assert isinstance(grid, list)
+    assert grid
+
+    result = []
+    for i_grid in grid:
+        result.append(gridify_dict(i_grid))
+
+    assert result
+    return result
+
+
+@overload
+def gridify(grid: dict) -> list[frozendict]: ...
+
+
+@overload
+def gridify(grid: list) -> list[list[frozendict]]: ...
+
+
+def gridify(grid):
+    """Factory qui construit les Sigmas.
+
+    :param grid: une grilles de paramètres
+    :return: Une liste de sigmas
+    """
+    name = f"gridify_{type(grid).__name__}"
+    return factory_function(concrete_product=name, package=__name__, grid=grid)

--- a/pfmg/parsing/features/utils.py
+++ b/pfmg/parsing/features/utils.py
@@ -9,7 +9,7 @@
 class FeatureReader:
     """TODO : Write some doc."""
 
-    def parse(self, data: str, target: str) -> list[dict]:
+    def parse(self, data: str, target: str = "") -> list[dict]:
         """TODO : Write some doc."""
         assert data
 
@@ -18,7 +18,7 @@ class FeatureReader:
         self.__read(
             data,
             target=target,
-            accumulator=accumulator,
+            accumulator=accumulator if nb_c > 1 else accumulator[0],
             separators=("scolon", "comma", "equal", "char"),
         )
         return accumulator

--- a/pfmg/test/lexique/glose/test_gloses.py
+++ b/pfmg/test/lexique/glose/test_gloses.py
@@ -3,97 +3,528 @@
 
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from pathlib import Path
 import pytest
 import yaml
 from frozendict import frozendict
+
+from pfmg.lexique.glose import new_gloses
 from pfmg.lexique.glose.Gloses import Gloses
+from pfmg.lexique.glose.Sigma import Sigma
+from pfmg.lexique.glose.Sigmas import Sigmas
 
-parametrize = pytest.mark.parametrize("gloses, expected", [
+parametrize = pytest.mark.parametrize(
+    "gloses, expected_data", [
 
-    ({"source": {"N": {"Genre": ["m"]}},
-      "destination": {"N": {"Genre": ["m"]}}},
-     {"source": {"N": [frozendict({"Genre": "m"})]},
-      "destination": {"N": [frozendict({"Genre": "m"})]}}),
+        ({
+             "source":      {
+                 "N": {
+                     "Genre": ["m"]
+                 }
+             },
+             "destination": {
+                 "N": {
+                     "Genre": ["m"]
+                 }
+             }
+         },
+         {
+             "N": Sigmas(
+                 [Sigma(
+                     **{
+                         "source":      frozendict(
+                             {
+                                 "Genre": "m"
+                             }
+                         ),
+                         "destination": frozendict(
+                             {
+                                 "Genre": "m"
+                             }
+                         )
+                     }
+                 )]
+             )
+         }),
 
-    ({"source": {"N": {"Genre": ["m", "f"]}},
-      "destination": {"N": {"Genre": ["m", "f"]}}},
-     {"source": {"N": [frozendict({"Genre": "m"}),
-                       frozendict({"Genre": "f"})]},
-      "destination": {"N": [frozendict({"Genre": "m"}),
-                            frozendict({"Genre": "f"})]}}),
+        ({
+             "source":      {
+                 "N": {
+                     "Genre": ["m", "f"]
+                 }
+             },
+             "destination": {
+                 "N": {
+                     "Genre": ["m", "f"]
+                 }
+             }
+         },
+         {
+             'N': Sigmas(
+                 data=[Sigma(
+                     source=frozendict(
+                         {
+                             'Genre': 'm'
+                         }
+                     ),
+                     destination=frozendict(
+                         {
+                             'Genre': 'm'
+                         }
+                     )
+                 ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre': 'm'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Genre': 'f'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre': 'f'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Genre': 'm'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre': 'f'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Genre': 'f'
+                             }
+                         )
+                     )]
+             )
+         }),
 
-    ({"source": {"N": {"Genre": ["m", "f"], "Nombre": ["sg", "pl"]}},
-      "destination": {"N": {"Cas": ["nom", "acc", "dat"]}}},
-     {"source": {"N": [frozendict({"Genre": "m",
-                                   "Nombre": "sg"}),
-                       frozendict({"Genre": "m",
-                                   "Nombre": "pl"}),
-                       frozendict({"Genre": "f",
-                                   "Nombre": "sg"}),
-                       frozendict({"Genre": "f",
-                                   "Nombre": "pl"})]},
-      "destination": {"N": [frozendict({"Cas": "nom"}),
-                            frozendict({"Cas": "acc"}),
-                            frozendict({"Cas": "dat"})]}}),
-])
+        ({
+             "source":      {
+                 "N": {
+                     "Genre":  ["m", "f"],
+                     "Nombre": ["sg", "pl"]
+                 }
+             },
+             "destination": {
+                 "N": {
+                     "Cas": ["nom", "acc", "dat"]
+                 }
+             }
+         },
+         {
+             'N': Sigmas(
+                 data=[Sigma(
+                     source=frozendict(
+                         {
+                             'Genre':  'm',
+                             'Nombre': 'sg'
+                         }
+                     ),
+                     destination=frozendict(
+                         {
+                             'Cas': 'nom'
+                         }
+                     )
+                 ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'm',
+                                 'Nombre': 'sg'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'acc'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'm',
+                                 'Nombre': 'sg'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'dat'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'm',
+                                 'Nombre': 'pl'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'nom'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'm',
+                                 'Nombre': 'pl'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'acc'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'm',
+                                 'Nombre': 'pl'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'dat'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'f',
+                                 'Nombre': 'sg'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'nom'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'f',
+                                 'Nombre': 'sg'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'acc'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'f',
+                                 'Nombre': 'sg'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'dat'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'f',
+                                 'Nombre': 'pl'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'nom'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'f',
+                                 'Nombre': 'pl'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'acc'
+                             }
+                         )
+                     ),
+                     Sigma(
+                         source=frozendict(
+                             {
+                                 'Genre':  'f',
+                                 'Nombre': 'pl'
+                             }
+                         ),
+                         destination=frozendict(
+                             {
+                                 'Cas': 'dat'
+                             }
+                         )
+                     )]
+             )
+         }
+        ),
+    ]
+)
 
 
 @parametrize
-def test_gloses_from_disk(tmp_path, gloses, expected) -> None:
+def test_gloses_from_disk(tmp_path, gloses, expected_data) -> None:
     gloses_path = tmp_path / "Gloses.yaml"
     with open(gloses_path, mode="w", encoding="utf8") as file_handler:
-        yaml.dump(gloses, file_handler)
+        yaml.safe_dump(gloses, file_handler)
     actual = Gloses.from_yaml(gloses_path)
-    expected = Gloses(**expected)
+    expected = Gloses(expected_data)
 
     assert actual == expected
 
 
-parametrize = pytest.mark.parametrize("params, expected", [
+parametrize = pytest.mark.parametrize(
+    "params, expected", [
 
-    ({"source": {"N": [frozendict({"Genre": "m"})]},
-      "destination": {"N": [frozendict({"Genre": "m"})]}},
-     [{"source": frozendict({"Genre": "m"}),
-       "destination": frozendict({"Genre": "m"})}]),
+        ({
+             "source":      {
+                 "N": {
+                     "Genre": ["m"]
+                 }
+             },
+             "destination": {
+                 "N": {
+                     "Genre": ["m"]
+                 }
+             }
+         },
+         Sigmas(
+             [Sigma(
+                 **{
+                     "source":      frozendict(
+                         {
+                             "Genre": "m"
+                         }
+                     ),
+                     "destination": frozendict(
+                         {
+                             "Genre": "m"
+                         }
+                     )
+                 }
+             )]
+         )),
 
-    ({"source": {"N": [frozendict({"Genre": "m"}),
-                       frozendict({"Genre": "f"})]},
-      "destination": {"N": [frozendict({"Genre": "m"}),
-                            frozendict({"Genre": "f"})]}},
-     [{"destination": frozendict({"Genre": "m"}),
-       "source": frozendict({"Genre": "m"})},
-      {"destination": frozendict({"Genre": "f"}),
-       "source": frozendict({"Genre": "m"})},
-      {"destination": frozendict({"Genre": "m"}),
-       "source": frozendict({"Genre": "f"})},
-      {"destination": frozendict({"Genre": "f"}),
-       "source": frozendict({"Genre": "f"})}]),
+        ({
+             "source":      {
+                 "N": {
+                     "Genre": ["m", "f"]
+                 }
+             },
+             "destination": {
+                 "N": {
+                     "Genre": ["m", "f"]
+                 }
+             }
+         },
+         Sigmas(
+             [
+                 Sigma(
+                     **{
+                         "destination": frozendict(
+                             {
+                                 "Genre": "m"
+                             }
+                         ),
+                         "source":      frozendict(
+                             {
+                                 "Genre": "m"
+                             }
+                         )
+                     }
+                 ),
+                 Sigma(
+                     **{
+                         "destination": frozendict(
+                             {
+                                 "Genre": "f"
+                             }
+                         ),
+                         "source":      frozendict(
+                             {
+                                 "Genre": "m"
+                             }
+                         )
+                     }
+                 ),
+                 Sigma(
+                     **{
+                         "destination": frozendict(
+                             {
+                                 "Genre": "m"
+                             }
+                         ),
+                         "source":      frozendict(
+                             {
+                                 "Genre": "f"
+                             }
+                         )
+                     }
+                 ),
+                 Sigma(
+                     **{
+                         "destination": frozendict(
+                             {
+                                 "Genre": "f"
+                             }
+                         ),
+                         "source":      frozendict(
+                             {
+                                 "Genre": "f"
+                             }
+                         )
+                     }
+                 )
+             ]
+         )),
 
-    ({"source": {"N": [frozendict({"Genre": "m",
-                                   "Nombre": "sg"}),
-                       frozendict({"Genre": "m",
-                                   "Nombre": "pl"}),
-                       frozendict({"Genre": "f",
-                                   "Nombre": "sg"}),
-                       frozendict({"Genre": "f",
-                                   "Nombre": "pl"})]},
-      "destination": {"N": [frozendict({"Cas": "m"})]}},
-     [{"destination": frozendict({"Cas": "m"}),
-       "source": frozendict({"Genre": "m",
-                             "Nombre": "sg"})},
-      {"destination": frozendict({"Cas": "m"}),
-       "source": frozendict({"Genre": "m",
-                             "Nombre": "pl"})},
-      {"destination": frozendict({"Cas": "m"}),
-       "source": frozendict({"Genre": "f",
-                             "Nombre": "sg"})},
-      {"destination": frozendict({"Cas": "m"}),
-       "source": frozendict({"Genre": "f", "Nombre": "pl"})}]),
-])
+        ({
+             "source":      {
+                 "N": {
+                     "Genre":  ["m", "f"],
+                     "Nombre": ["sg", "pl"]
+                 }
+             },
+             "destination": {
+                 "N": {
+                     "Cas": ["m"]
+                 }
+             }
+         },
+         Sigmas(
+             [
+                 Sigma(
+                     **{
+                         "destination": frozendict(
+                             {
+                                 "Cas": "m"
+                             }
+                         ),
+                         "source":      frozendict(
+                             {
+                                 "Genre":  "m",
+                                 "Nombre": "sg"
+                             }
+                         )
+                     }
+                 ),
+                 Sigma(
+                     **{
+                         "destination": frozendict(
+                             {
+                                 "Cas": "m"
+                             }
+                         ),
+                         "source":      frozendict(
+                             {
+                                 "Genre":  "m",
+                                 "Nombre": "pl"
+                             }
+                         )
+                     }
+                 ),
+                 Sigma(
+                     **{
+                         "destination": frozendict(
+                             {
+                                 "Cas": "m"
+                             }
+                         ),
+                         "source":      frozendict(
+                             {
+                                 "Genre":  "f",
+                                 "Nombre": "sg"
+                             }
+                         )
+                     }
+                 ),
+                 Sigma(
+                     **{
+                         "destination": frozendict(
+                             {
+                                 "Cas": "m"
+                             }
+                         ),
+                         "source":      frozendict(
+                             {
+                                 "Genre":  "f",
+                                 "Nombre": "pl"
+                             }
+                         )
+                     }
+                 )
+             ]
+         )),
+    ]
+)
 
 
 @parametrize
-def test__call__(tmp_path, params, expected) -> None:
-    gloses = Gloses(**params)
+def test__call__(params, expected) -> None:
+    gloses = Gloses.from_dict(params)
     actual = gloses(pos="N")
     assert actual == expected
+
+
+parametrize = pytest.mark.parametrize(
+    "params, expected_type, expected_type_2", [
+        ({
+             "source":      {
+                 "N": {
+                     "Genre": ["m"]
+                 }
+             },
+             "destination": {
+                 "N": {
+                     "Genre": ["m"]
+                 }
+             }
+         },
+         "Gloses",
+         "Sigmas"),
+
+    ]
+)
+
+
+@parametrize
+def test_alignments_constraints(
+    tmp_path,
+    params,
+    expected_type,
+    expected_type_2
+) -> None:
+    filename = tmp_path / "Gloses.yaml"
+    with filename.open(mode="w") as fh:
+        yaml.safe_dump(params, fh)
+    gloses = new_gloses(Path(filename))
+    assert gloses.__class__.__name__ == expected_type
+    assert gloses("N").__class__.__name__ == expected_type_2

--- a/pfmg/test/parsing/features/__init__.py
+++ b/pfmg/test/parsing/features/__init__.py
@@ -14,33 +14,41 @@ parametrize = pytest.mark.parametrize(
         # ("Genre",
         #  "s",
         #  [{"sGenre": "?sGenre"}]),
-        #
-        # ("Genre,Nombre",
-        #  "s",
-        #  [{"sGenre": "?sGenre", "sNombre": "?sNombre"}]),
-        #
-        # ("Genre;Nombre",
-        #  "s",
-        #  [{"sGenre": "?sGenre"}, {"sNombre": "?sNombre"}]),
-        #
-        # ("Genre=m",
-        #  "s",
-        #  [{"sGenre": "m"}]),
-        #
-        # ("Genre,Nombre;Genre,Nombre",
-        #  "s",
-        #  [{"sGenre":  "?sGenre", "sNombre": "?sNombre"},
-        #   {"sGenre":  "?sGenre", "sNombre": "?sNombre"}]),
-        #
-        # ("Genre,Nombre;Genre,Nombre;Cas=erg",
-        #  "s",
-        #  [{"sGenre":  "?sGenre", "sNombre": "?sNombre"},
-        #   {"sGenre":  "?sGenre", "sNombre": "?sNombre"},
-        #   {"sCas":  "erg"}]),
-        #
-        # ("Genre;;", "s", [{"sGenre":  "?sGenre"}, {}, {}]),
 
-        ("Genre;;Nombre", "s", [{"sGenre":  "?sGenre"}, {}, {"sNombre": "?sNombre"}]),
+        ("Genre,Nombre",
+         "s",
+         [{"sGenre": "?sGenre", "sNombre": "?sNombre"}]),
+
+        ("Genre;Nombre",
+         "s",
+         [{"sGenre": "?sGenre"}, {"sNombre": "?sNombre"}]),
+
+        ("Genre=m",
+         "s",
+         [{"sGenre": "m"}]),
+
+        ("Genre,Nombre;Genre,Nombre",
+         "s",
+         [{"sGenre":  "?sGenre", "sNombre": "?sNombre"},
+          {"sGenre":  "?sGenre", "sNombre": "?sNombre"}]),
+
+        ("Genre,Nombre;Genre,Nombre;Cas=erg",
+         "s",
+         [{"sGenre":  "?sGenre", "sNombre": "?sNombre"},
+          {"sGenre":  "?sGenre", "sNombre": "?sNombre"},
+          {"sCas":  "erg"}]),
+
+        ("Genre;;",
+         "s",
+         [{"sGenre":  "?sGenre"}, {}, {}]),
+
+        ("Genre;;Nombre",
+         "s",
+         [{"sGenre":  "?sGenre"}, {}, {"sNombre": "?sNombre"}]),
+
+        ("Genre=m,Nombre",
+         "s",
+         [{"sGenre":  "m", "sNombre": "?sNombre"}]),
     ]
 )
 
@@ -49,12 +57,3 @@ parametrize = pytest.mark.parametrize(
 def test_features_parse(data, target, expected):
     features = FeatureReader().parse(data, target=target)
     assert features == expected
-
-
-# parametrize = pytest.mark.parametrize()
-#
-#
-# @parametrize
-# def test_features_parse(data, target, expected):
-#     features = Features()
-#     assert features == expected


### PR DESCRIPTION
Cette nouvelle feature permet de créer un lien entre source et destination et ainsi restreindre le produit cartésien si besoin.

J'ai séparé Gloses de CGloses, ainsi s'il n'y a pas de champs alignements dans Gloses.yaml, on construira Gloses, sinon CGloses.

J'ai introduit deux nouvelles structures de données en plus de CGloses : Sigma et Sigmas.
La deuxième est l'ensemble de la première tandis que la première contient les infos morphsyntaxiques (sigmas) de source et destination.