### PR TITLE
#42 : Change la structure de Blocks.yaml

### DIFF
--- a/examples/data/Blocks.yaml
+++ b/examples/data/Blocks.yaml
@@ -1,18 +1,18 @@
-source:
-  D:
+D:
+  source:
     - Genre=m,Nombre=sg: X1
       Genre=f,Nombre=sg: X2
       Nombre=pl: X3
-  NOM:
-    - Nombre=pl: X2?X2:X+s
-destination:
-  D:
+  destination:
     - Genre=m: X+o
       Genre=f: X+i
       Genre=n: X+e
     - Nombre=sg: X+s
       Nombre=pl: X+j
-  NOM:
+NOM:
+  source:
+    - Nombre=pl: X2?X2:X+s
+  destination:
     - Cf=n1,Nombre=sg: X+v
       Cf=n1,Nombre=pl: X+l
       Cf=n2,Nombre=sg: X+j

--- a/pfmg/lexique/block/BlockEntry.py
+++ b/pfmg/lexique/block/BlockEntry.py
@@ -27,7 +27,7 @@ class BlockEntry:
         """Vérifie les structures d'entrées.
 
         Pour garder les structures le plus propre possible,
-        Tout entrée vide est refusée.
+        Toute entrée vide est refusée.
         """
         assert self.source
         assert self.destination

--- a/pfmg/lexique/block/BlockEntry.py
+++ b/pfmg/lexique/block/BlockEntry.py
@@ -3,160 +3,68 @@
 
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-"""Entry d'un Bloc. Structure de données contenant les règles d'un Bloc."""
+"""Structure qui génère des Desinence."""
 
-from collections.abc import Iterator
 from dataclasses import dataclass
+from pathlib import Path
 
-from frozendict import frozendict
+import yaml
 
-from pfmg.external.display import ABCDisplay
-from pfmg.lexique.morpheme.Factory import create_morpheme
+from pfmg.lexique.block.Blocks import Blocks
+from pfmg.lexique.block.Desinence import Desinence
+from pfmg.lexique.glose.Sigma import Sigma
 from pfmg.lexique.phonology.Phonology import Phonology
-from pfmg.lexique.selector.ABCSelector import ABCSelector
-from pfmg.lexique.utils import dictify
 
 
 @dataclass
-class BlockEntry(ABCSelector):
-    """Entry d'un Bloc. Structure de données contenant les règles d'un Bloc."""
+class BlockEntry:
+    """Structure qui génère des Desinence."""
 
-    data: dict[str, list[list[ABCDisplay]]]
+    source: dict[str, Blocks]
+    destination: dict[str, Blocks]
 
     def __post_init__(self):
-        """Vérfication de base sur 'data'."""
-        assert self.data
-        assert all(self.data.values())
-        assert all(all(x) for x in self.data.values())
+        """Vérifie les structures d'entrées.
 
-    def __call__(
-        self,
-        pos: str,
-        sigma: frozendict,
-    ) -> list[ABCDisplay]:
-        """Calcule les morphèmes disponible pour le couple POS/sigma.
-
-        :param pos: un POS disponible
-        :param sigma: un sigma associé à ce POS
-        :return: les morphèmes existant dans les blocs
+        Pour garder les structures le plus propre possible,
+        Tout entrée vide est refusée.
         """
-        if pos not in self.data:
-            message = (
-                f"'{pos}' n'est pas dans les catégories disponibles "
-                f"{list(self.data.keys())}."
-            )
-            raise KeyError(message)
+        assert self.source
+        assert self.destination
 
-        output: list[ABCDisplay] = []
+    def __call__(self, pos: str, sigma: Sigma) -> Desinence:
+        """Construit un Desinence si le couple pos/sigma le permet.
 
-        for bloc in self.data[pos]:
-            morpheme = BlockEntry.__select_morpheme(sigma, bloc)
-            if morpheme is not None:
-                output.append(morpheme)
-        return output
+        :param pos: un POS disponible dans source et destination
+        :param sigma: un Sigma valide
+        :return: Instance de Desinence
+        """
+        return Desinence(
+            source=self.source[pos](sigma.source),
+            destination=self.destination[pos](sigma.destination),
+        )
 
     @classmethod
-    def from_dict(
-        cls,
-        data: dict[str, list[dict[str, str]]],
-        phonology: Phonology,
-    ) -> "BlockEntry":
-        """Construit un BlockEntry depuis un dictionnaire.
+    def from_yaml(cls, path: Path) -> "BlockEntry":
+        """Construit un BlockEntry depuis un fichier yaml.
 
-        TODO : changer le type de 'data' en un TypedDict ou équivalent.
-
-        :param data:
-        :param phonology:
-        :return:
+        :param path: Chemin vers le fichier yaml
+        :return: un BlockEntry prêt à l'emploi
         """
-        return cls(
-            data={
-                category: list(cls.__rulify(block=rules, phonology=phonology))
-                for category, rules in data.items()
-            },
+        assert path.name.endswith("Blocks.yaml")
+
+        phonology = Phonology.from_yaml(
+            path.parent / "Phonology.yaml",
         )
 
-    @staticmethod
-    def __rulify(
-        block: dict[str, str] | list[dict[str, str]],
-        phonology: Phonology,
-    ) -> Iterator[list[ABCDisplay]]:
-        """Factory qui met en forme 'block' pour être facilement interrogé.
+        with open(path, encoding="utf8") as file_handler:
+            data: dict = yaml.safe_load(file_handler)
 
-        :param block: Bloc ou liste de blocs de règles
-        :return: liste de blocs au format frozendict/Morpheme
-        """
-        method_name = (
-            f"_{BlockEntry.__name__}__rulify_"
-            f"{block.__class__.__name__.lower()}"
-        )
-        return getattr(
-            BlockEntry,
-            method_name,
-        )(
-            block=block,
-            phonology=phonology,
-        )
-
-    @staticmethod
-    def __rulify_dict(
-        block: dict[str, str],
-        phonology: Phonology,
-    ) -> Iterator[list[ABCDisplay]]:
-        """Met en forme un bloc.
-
-        :param block: Bloc de règles
-        :return: liste de blocs au format frozendict/Morpheme
-        """
-        if not block:
-            raise ValueError
-
-        output: list[ABCDisplay] = []
-
-        for key, value in block.items():
-            _sigma = dictify(key)
-            output.append(
-                create_morpheme(
-                    rule=value,
-                    sigma=_sigma,
-                    phonology=phonology,
-                ),
+        sources = {}
+        destinations = {}
+        for pos, blocks in data.items():
+            sources[pos] = Blocks.from_list(blocks["source"], phonology)
+            destinations[pos] = Blocks.from_list(
+                blocks["destination"], phonology
             )
-
-        yield output
-
-    @staticmethod
-    def __rulify_list(
-        block: list[dict[str, str]],
-        phonology: Phonology,
-    ) -> Iterator[list[ABCDisplay]]:
-        """Met en forme une liste de blocs.
-
-        :param block: Liste de blocs de règles
-        :return: liste de blocs au format frozendict/Morpheme
-        """
-        if not block:
-            raise ValueError
-
-        for i_block in block:
-            yield from BlockEntry.__rulify_dict(
-                block=i_block,
-                phonology=phonology,
-            )
-
-    @staticmethod
-    def __select_morpheme(
-        sigma: frozendict,
-        morphemes: list[ABCDisplay],
-    ) -> ABCDisplay | None:
-        """Sélectionne un morphème si sigma contient morphemes[i].sigma.
-
-        :param sigma: sigma d'un léxème
-        :param morphemes: liste de morphèmes
-        :return: le morphème le plus général lors du "<="
-        """
-        winner: ABCDisplay | None = None
-        for morpheme in morphemes:
-            if morpheme.get_sigma().items() <= sigma.items():
-                winner = morpheme
-        return winner
+        return cls(sources, destinations)

--- a/pfmg/lexique/block/Blocks.py
+++ b/pfmg/lexique/block/Blocks.py
@@ -6,70 +6,70 @@
 """Blocks."""
 
 from dataclasses import dataclass
-from pathlib import Path
 
-import yaml
 from frozendict import frozendict
 
-from pfmg.external.reader.ABCReader import ABCReader
-from pfmg.lexique.block.BlockEntry import BlockEntry
+from pfmg.lexique.morpheme.Factory import create_morpheme
 from pfmg.lexique.phonology.Phonology import Phonology
+from pfmg.parsing.features.utils import FeatureReader
 
 
 @dataclass
-class Blocks(ABCReader):
-    """Réprésente les blocs d'application de règles."""
+class Blocks:
+    """Blocks."""
 
-    source: BlockEntry
-    destination: BlockEntry
+    data: list[list["Morpheme"]]  # noqa # type: ignore
 
     def __post_init__(self):
-        """Vérification après initialisation."""
-        assert self.source
-        assert self.destination
+        """Vérifie les structures d'entrées.
+
+        Pour garder les structures le plus propre possible,
+        Tout entrée vide est refusée.
+        """
+        assert self.data
+        assert all(x for x in self.data)
+
+    def __call__(self, sigma: frozendict) -> list["Morpheme"]:  # noqa # type: ignore
+        """Récupère la liste de morphèmes valides pour le sigma donné.
+
+        :param sigma: le sigma d'une forme
+        :return: une liste de morphème valide pour ce sigma
+        """
+        assert sigma
+
+        output: list["Morpheme"] = []  # noqa # type: ignore
+        for morphemes in self.data:
+            winner: "Morpheme | None" = None  # noqa # type: ignore
+            for morpheme in morphemes:
+                if morpheme.get_sigma().items() <= sigma.items():
+                    winner = morpheme
+            if winner is not None:
+                output.append(winner)
+        return output
 
     @classmethod
-    def from_yaml(cls, path: Path) -> "Blocks":
-        """Construit un Blocks depuis un fichier JSON.
+    def from_list(cls, data: list[dict], phonology: "Phonology") -> "Blocks":  # type: ignore
+        """Construit un Blocks à partir dd'une liste de blocs.
 
-        :param path: Chemin vers le fichier JSON
-        :return: une instance de Blocks
+        :param data: listes de bloc pour un pos donné
+        :param phonology: Instance de Phonology
+        :return: un Blocks prêt à l'emploi
         """
-        assert path.name.endswith("Blocks.yaml")
+        output: list[list["Morpheme"]] = []  # noqa # type: ignore
 
-        with open(path, encoding="utf8") as file_handler:
-            data: dict = yaml.load(file_handler, Loader=yaml.Loader)
+        fr = FeatureReader()
+        for block in data:
+            _tmp = []
+            for key, value in block.items():
+                _sigma = frozendict(fr.parse(key)[0])
+                _tmp.append(
+                    create_morpheme(
+                        rule=value,
+                        sigma=_sigma,
+                        phonology=phonology,
+                    ),
+                )
+            output.append(_tmp)
 
-        assert data
-
-        phonology_from_disk = Phonology.from_yaml(
-            path.parent / "Phonology.yaml",
-        )
-
-        source = BlockEntry.from_dict(
-            data=data["source"],
-            phonology=phonology_from_disk,
-        )
-
-        destination = BlockEntry.from_dict(
-            data=data["destination"],
-            phonology=phonology_from_disk,
-        )
-
-        return cls(source=source, destination=destination)
-
-    def __call__(
-        self,
-        pos: str,
-        sigma: frozendict,
-    ) -> dict:
-        """Construit un dictionnaire avec en clé les POS et les blocs en valeurs.
-
-        :param pos:
-        :param sigma:
-        :return:
-        """
-        return {
-            key: getattr(self, key)(pos, sigma[key])
-            for key, value in sigma.items()
-        }
+        assert output
+        return cls(output)

--- a/pfmg/lexique/block/Blocks.py
+++ b/pfmg/lexique/block/Blocks.py
@@ -24,7 +24,7 @@ class Blocks:
         """Vérifie les structures d'entrées.
 
         Pour garder les structures le plus propre possible,
-        Tout entrée vide est refusée.
+        Toute entrée vide est refusée.
         """
         assert self.data
         assert all(x for x in self.data)
@@ -49,7 +49,7 @@ class Blocks:
 
     @classmethod
     def from_list(cls, data: list[dict], phonology: "Phonology") -> "Blocks":  # type: ignore
-        """Construit un Blocks à partir dd'une liste de blocs.
+        """Construit un Blocks à partir d'une liste de blocs.
 
         :param data: listes de bloc pour un pos donné
         :param phonology: Instance de Phonology

--- a/pfmg/lexique/block/Desinence.py
+++ b/pfmg/lexique/block/Desinence.py
@@ -1,0 +1,11 @@
+"""Désinence."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Desinence:
+    """Ensemble de morphèmes pour source/destination."""
+
+    source: list["Morpheme"]  # noqa # type: ignore
+    destination: list["Morpheme"]  # noqa # type: ignore

--- a/pfmg/lexique/morpheme/Factory.py
+++ b/pfmg/lexique/morpheme/Factory.py
@@ -9,7 +9,6 @@ from enum import Enum
 
 from frozendict import frozendict
 
-from pfmg.external.display import ABCDisplay
 from pfmg.lexique.phonology.Phonology import Phonology
 from pfmg.utils.abstract_factory import factory_method
 
@@ -29,7 +28,7 @@ def create_morpheme(
     rule: str,
     sigma: frozendict,
     phonology: Phonology,
-) -> ABCDisplay:
+) -> "Morpheme":  # noqa # type: ignore
     """Factory pour construire n'importe quel morphème.
 
     :param rule: une règle valide

--- a/pfmg/test/lexique/block/test_block_entry.py
+++ b/pfmg/test/lexique/block/test_block_entry.py
@@ -3,11 +3,18 @@
 
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
+from functools import cache
 from collections.abc import Generator
+
+import pytest
+import yaml
 from frozendict import frozendict
 
+from pfmg.lexique.block.Blocks import Blocks
 from pfmg.lexique.block.BlockEntry import BlockEntry
+from pfmg.lexique.block.Desinence import Desinence
+from pfmg.lexique.glose.Sigma import Sigma
+from pfmg.lexique.morpheme.Circumfix import Circumfix
 from pfmg.lexique.phonology.Phonology import Phonology
 from pfmg.lexique.morpheme.Suffix import Suffix
 
@@ -17,7 +24,8 @@ def fx_phonology() -> Generator[Phonology, None, None]:
     yield phonology()
 
 
-def phonology():
+@cache
+def phonology() -> Phonology:
     return Phonology(
         apophonies=frozendict(
             Ø="i", i="a", a="u",
@@ -35,221 +43,48 @@ def phonology():
     )
 
 
-@pytest.mark.parametrize(
-    "blocks, expected", [
-        ({"N": [{"CF=N1,Nombre=Sg": "X+v"}]},
-         {"N": [[Suffix(
-             rule="X+v",
-             sigma=frozendict(CF="N1", Nombre="Sg"),
-             phonology=phonology()
-         )]]})
-    ]
-)
-def test_from_dict(fx_phonology, blocks, expected) -> None:
-    actual = BlockEntry.from_dict(blocks, fx_phonology)
-    assert isinstance(actual, BlockEntry)
-    assert actual.data == expected
+@pytest.mark.parametrize("blocks, expected", [
+    ({"N": {"source": [{"genre=m": "X+s"}], "destination": [{"cas=erg": "a+X+s"}]}},
+     ({"N": Blocks([[Suffix(rule="X+s", sigma=frozendict(genre="m"), phonology=phonology())]])},
+      {"N": Blocks([[Circumfix(rule="a+X+s", sigma=frozendict(cas="erg"), phonology=phonology())]])})),])
+def test_blocks(fx_phonology, tmp_path, blocks, expected):
+    with open(tmp_path / "Phonology.yaml", mode="w", encoding="utf8") as file_handler:
+        yaml.safe_dump(fx_phonology.to_dict(), file_handler)
+
+    with open(tmp_path / "Blocks.yaml", mode="w", encoding="utf8") as file_handler:
+        yaml.safe_dump(blocks, file_handler)
+    blocks = BlockEntry.from_yaml(tmp_path / "Blocks.yaml")
+    assert blocks.source == expected[0]
+    assert blocks.destination == expected[1]
 
 
-def test___call__() -> None:
-    blocks = BlockEntry(
-        data={"N": [[Suffix(
-            rule="X+v",
-            sigma=frozendict(Genre="m", Nombre="sg"),
-            phonology=phonology()
-        )]]}
-    )
-    actual = blocks(pos="N", sigma=frozendict())
-    expected = []
-    assert actual == expected
+@pytest.mark.parametrize("blocks, pos, sigma, expected", [
+    ({"N": {"source":      [{"genre=m": "X+s"}],
+            "destination": [{"cas=erg": "a+X+s"}]}},
+     "N",
+     {"source":      frozendict(genre="m"),
+      "destination": frozendict(cas="erg")},
+     Desinence(
+         source=[Suffix(rule="X+s", sigma=frozendict(genre="m"),
+                        phonology=phonology())],
+         destination=[Circumfix(rule="a+X+s", sigma=frozendict(cas="erg"),
+                                phonology=phonology())])),
+])
+def test___call__(fx_phonology, tmp_path, blocks, pos, sigma, expected):
+    with open(tmp_path / "Phonology.yaml", mode="w", encoding="utf8") as file_handler:
+        yaml.safe_dump(fx_phonology.to_dict(), file_handler)
 
-    actual = blocks(pos="N", sigma=frozendict(Genre="f", Nombre="sg"))
-    expected = []
-    assert actual == expected
-
-    actual = blocks(pos="N", sigma=frozendict(Genre="m", Nombre="sg"))
-    expected = [Suffix(
-        rule="X+v",
-        sigma=frozendict(Genre="m", Nombre="sg"),
-        phonology=phonology()
-    )]
-    assert actual == expected
-
-    actual = blocks(
-        pos="N",
-        sigma=frozendict(Genre="m", Nombre="sg", Cas="erg")
-    )
-    expected = [Suffix(
-        rule="X+v",
-        sigma=frozendict(Genre="m", Nombre="sg"),
-        phonology=phonology()
-    )]
-    assert actual == expected
+    with open(tmp_path / "Blocks.yaml", mode="w", encoding="utf8") as file_handler:
+        yaml.safe_dump(blocks, file_handler)
+    blocks = BlockEntry.from_yaml(tmp_path / "Blocks.yaml")
+    assert blocks(pos, Sigma(**sigma)) == expected
 
 
-def test_raise_errors():
+def test_errors():
     with pytest.raises(AssertionError):
-        _ = BlockEntry(data={})
+        BlockEntry(source={},
+                   destination={"N": Blocks([])})
 
     with pytest.raises(AssertionError):
-        _ = BlockEntry(data={"N": []})
-
-    with pytest.raises(AssertionError):
-        _ = BlockEntry(data={"N": [[], [{"qqch"}]]})  # type: ignore
-
-    with pytest.raises(KeyError):
-        _ = BlockEntry(
-            data={"N": [[Suffix(
-                rule="X+v",
-                sigma=frozendict(Genre="m", Nombre="sg"),
-                phonology=phonology()
-            )]]}
-        )(pos="NOUN", sigma=frozendict())
-        
-    with pytest.raises(KeyError):
-        _ = BlockEntry(
-            data={"N": [[Suffix(
-                rule="X+v",
-                sigma=frozendict(Genre="m", Nombre="sg"),
-                phonology=phonology()
-            )]]}
-        )(pos="NOUN", sigma=frozendict(Genre="m", Nombre="sg"))
-        
-    with pytest.raises(ValueError):
-        _ = BlockEntry.from_dict(data={"N": []}, phonology=phonology())
-
-    with pytest.raises(ValueError):
-        _ = BlockEntry.from_dict(data={"N": [{}]}, phonology=phonology())
-
-
-# @pytest.mark.parametrize(
-#     "blocks, phonology, expected", [
-#         ({"N": []},
-#          dict(
-#              apophonies=frozendict(Ø="i", i="a", a="u",
-#                                    u="u", e="o", o="o"),
-#              mutations=frozendict(
-#                  p="p", t="p", k="t", b="p", d="b",
-#                  g="d", m="m", n="m", N="n", f="f",
-#                  s="f", S="s", v="f", z="v", Z="z",
-#                  r="w", l="r", j="w", w="w"
-#              ),
-#              derives=frozendict(A="V", D="C"),
-#              consonnes=frozenset("ptkbdgmnNfsSvzZrljw"),
-#              voyelles=frozenset("iueoa")
-#          ),
-#          {}),
-# 
-#         ({"N": [{}]},
-#          dict(
-#              apophonies=frozendict(Ø="i", i="a", a="u",
-#                                    u="u", e="o", o="o"),
-#              mutations=frozendict(
-#                  p="p", t="p", k="t", b="p", d="b",
-#                  g="d", m="m", n="m", N="n", f="f",
-#                  s="f", S="s", v="f", z="v", Z="z",
-#                  r="w", l="r", j="w", w="w"
-#              ),
-#              derives=frozendict(A="V", D="C"),
-#              consonnes=frozenset("ptkbdgmnNfsSvzZrljw"),
-#              voyelles=frozenset("iueoa")
-#          ),
-#          {}),
-#     ]
-# )
-# def test_from_disk_errors(
-#     tmp_path,
-#     blocks,
-#     phonology,
-#     expected
-# ) -> None:
-#     blocks_path = tmp_path / "Blocks.yaml"
-#     with open(blocks_path, mode="w", encoding="utf8") as file_handler:
-#         yaml.dump(blocks, file_handler)
-# 
-#     phono_path = tmp_path / "Phonology.yaml"
-#     with open(phono_path, mode="w", encoding="utf8") as file_handler:
-#         yaml.dump(phonology, file_handler)
-# 
-#     with pytest.raises(ValueError):
-#         _ = BlockEntry.from_disk(blocks_path)
-# 
-# 
-# @pytest.mark.parametrize(
-#     "blocks, pos, sigma, expected", [
-# 
-#         # Aucun morpheme trouvé : le sigma est totalement différent.
-#         ({"N": [{"Genre=m,Nombre=pl": "X+s"}]},
-#          "N", frozendict(Genre="f"), []),
-# 
-#         # Aucun morphème trouvé : le sigma n'inclut pas celui 
-#         # d'un des sigmas des morphèmes de Blocks.N
-#         ({"N": [{"Genre=m,Nombre=pl": "X+s"}]},
-#          "N", frozendict(Genre="m"), []),
-# 
-#         # Un morphème trouvé : le sigma correspond exactement 
-#         # à l'un des sigmas des morphèmes de Blocks.N.
-#         ({"N": [{"Genre=m,Nombre=pl": "X+s"}]},
-#          "N", frozendict(Genre="m", Nombre="pl"),
-#          [create_morpheme(
-#              rule="X+s",
-#              sigma=frozendict(Genre="m", Nombre="pl", Cas="erg"),
-#              phonology=fx_phonology()
-#          )]),
-# 
-#         # Un morphème trouvé : le sigma inclut un des morphèmes de Blocks.N.
-#         ({"N": [{"Genre=m,Nombre=pl": "X+s"}]},
-#          "N",
-#          frozendict(Genre="m", Nombre="pl", Cas="erg"),
-#          [create_morpheme(
-#              rule="X+s",
-#              sigma=frozendict(Genre="m", Nombre="pl", Cas="erg"),
-#              phonology=fx_phonology()
-#          )]),
-# 
-#     ]
-# )
-# def test_select_morphemes(tmp_path, blocks, pos, sigma, expected) -> None:
-#     blocks_path = tmp_path / "Blocks.yaml"
-#     with open(blocks_path, mode="w", encoding="utf8") as file_handler:
-#         yaml.dump(blocks, file_handler)
-# 
-#     phono_path = tmp_path / "Phonology.yaml"
-#     with open(phono_path, mode="w", encoding="utf8") as file_handler:
-#         yaml.dump(fx_phonology().__dict__, file_handler)
-# 
-#     _blocks = BlockEntry.from_dict(blocks_path)
-#     actual = _blocks(pos=pos, sigma=sigma)
-#     assert actual == expected
-# 
-# 
-# def test_select_morphemes_errors(tmp_path) -> None:
-#     blocks_path = tmp_path / "Blocks.yaml"
-#     with open(blocks_path, mode="w", encoding="utf8") as file_handler:
-#         yaml.dump({}, file_handler)
-# 
-#     phono_path = tmp_path / "Phonology.yaml"
-#     with open(phono_path, mode="w", encoding="utf8") as file_handler:
-#         yaml.dump(fx_phonology().__dict__, file_handler)
-# 
-#     _blocks = BlockEntry.from_disk(blocks_path)
-#     with pytest.raises(KeyError):
-#         # POS n'est pas dans blocks
-#         _ = _blocks(
-#             pos="N",
-#             sigma=frozendict(Genre="m", Nombre="pl")
-#         )
-# 
-#     with pytest.raises(KeyError):
-#         # POS est dans blocks, mais sigma n'est pas dans blocks[POS]
-#         _ = _blocks(
-#             pos="N",
-#             sigma=frozendict(Genre="m", Nombre="pl")
-#         )
-# 
-#     with pytest.raises(KeyError):
-#         # POS est dans blocks, mais sigma n'est pas dans blocks[POS]
-#         _ = _blocks(
-#             pos="N",
-#             sigma=frozendict(Genre="m", Nombre="pl", Cas="erg")
-#         )
+        BlockEntry(source={"N": Blocks([])},
+                   destination={})

--- a/pfmg/test/lexique/block/test_blocks.py
+++ b/pfmg/test/lexique/block/test_blocks.py
@@ -51,9 +51,6 @@ def test___call__() -> None:
     blocks = Blocks(
         data=[[Suffix(rule="X+v", sigma=frozendict(Genre="m", Nombre="sg"),
                       phonology=phonology())]])
-    # actual = blocks(sigma=frozendict())
-    # expected = []
-    # assert actual == expected
 
     actual = blocks(sigma=frozendict(Genre="f", Nombre="sg"))
     expected = []

--- a/pfmg/test/lexique/main/data2_for_test/grammar/Blocks.yaml
+++ b/pfmg/test/lexique/main/data2_for_test/grammar/Blocks.yaml
@@ -1,9 +1,7 @@
-source:
-  NOM:
+NOM:
+  source:
     - Nombre=pl: X2?X2:X+s
-#    - Nombre=pl: X+s
-destination:
-  NOM:
+  destination:
     - Cf=n1,Nombre=sg: X+v
       Cf=n1,Nombre=pl: X+l
       Cf=n2,Nombre=sg: X+j

--- a/pfmg/test/lexique/paradigm/test_paradigm.py
+++ b/pfmg/test/lexique/paradigm/test_paradigm.py
@@ -83,8 +83,8 @@ def test_from_disk(tmp_path):
                     "destination": {"Genre":  ["m"],
                                     "Nombre": ["sg"]}}}
 
-    blocks = {"source": {"N": [{"Nombre=pl": "X+s"}]},
-              "destination": {"N": [{"Nombre=pl": "X+s"}]}}
+    blocks = {"N": {"source": [{"Nombre=pl": "X+s"}],
+                    "destination": [{"Nombre=pl": "X+s"}]}}
 
     _path = tmp_path / "Blocks.yaml"
     with open(_path, mode="w", encoding="utf8") as file_handler:


### PR DESCRIPTION
À l'image de gloses.yaml, j'ai restructuré blocks.yaml afin d'avoir le pos en clé la plus à l'extérieur.

```yaml
NOM:
  source:
    - Nombre=pl: X2?X2:X+s
  destination:
    - Cf=n1,Nombre=sg: X+v
      Cf=n1,Nombre=pl: X+l
      Cf=n2,Nombre=sg: X+j
      Cf=n2,Nombre=pl: X+g
```