### PR TITLE
ci: use PAT_ADMIN in bump-version workflow for protected branches

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,6 +1,8 @@
 # Bump version and regenerate lockfile on push to dev (patch) or main (minor).
 # Skips when the head commit message starts with "chore: update" to avoid loops.
-
+#
+# For protected branches (dev/main): create a repo secret PAT_ADMIN (Personal Access
+# Token of a user with admin rights) so the workflow can push. See .github/BRANCH_PROTECTION.md.
 name: Bump version
 
 on:
@@ -19,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_ADMIN }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
@@ -48,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_ADMIN }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"


### PR DESCRIPTION
## Related ticket

N/A (follow-up to branch protection: workflow must push with a token that can bypass PR requirement)

## Description

- Use `secrets.PAT_ADMIN` instead of `GITHUB_TOKEN` in `bump-version.yml` for both jobs (bump-patch-on-dev, bump-minor-on-main).
- Allows the workflow to push version-bump commits to protected `dev` and `main` when the repo uses "Require a pull request" (personal repos: PAT of an admin bypasses by default).
- Add comment in workflow pointing to branch protection doc and `PAT_ADMIN` secret.

## Documentation and additional notes

Create repository secret `PAT_ADMIN` (Personal Access Token with repo / Contents write) in Settings → Secrets and variables → Actions.

Made with [Cursor](https://cursor.com)