### PR TITLE
ci: sign bump-version commits with GPG, use vars for committer

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,8 +1,11 @@
 # Bump version and regenerate lockfile on push to dev (patch) or main (minor).
 # Skips when the head commit message starts with "chore: update" to avoid loops.
 #
-# For protected branches (dev/main): create a repo secret PAT_ADMIN (Personal Access
-# Token of a user with admin rights) so the workflow can push. See .github/BRANCH_PROTECTION.md.
+# For protected branches (dev/main):
+# - PAT_ADMIN: Personal Access Token of a user with admin rights (to bypass "Require PR").
+# - GPG_PRIVATE_KEY: ASCII-armored GPG private key (gpg --armor --export-secret-keys KEY_ID).
+# - GPG_PASSPHRASE: Passphrase of the key. If the key has no passphrase, do not create this secret (GitHub rejects empty values).
+# - COMMITTER_NAME, COMMITTER_EMAIL: Repository variables; must match the GitHub account that has the GPG key (verified commits).
 name: Bump version
 
 on:
@@ -22,11 +25,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT_ADMIN }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_committer_name: ${{ vars.COMMITTER_NAME }}
+          git_committer_email: ${{ vars.COMMITTER_EMAIL }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Bump patch version (dev), regenerate lockfile, commit and push
         env:
           UV_SYSTEM_PYTHON: "1"
@@ -36,8 +46,6 @@ jobs:
           OLD=$(uv version --short)
           uv version --bump patch
           NEW=$(uv version --short)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml uv.lock
           git diff --staged --quiet || git commit -m "chore: update $OLD to $NEW"
           git push
@@ -51,11 +59,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT_ADMIN }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_committer_name: ${{ vars.COMMITTER_NAME }}
+          git_committer_email: ${{ vars.COMMITTER_EMAIL }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Bump minor version (dev → main), regenerate lockfile, commit and push
         env:
           UV_SYSTEM_PYTHON: "1"
@@ -65,8 +80,6 @@ jobs:
           OLD=$(uv version --short)
           uv version --bump minor
           NEW=$(uv version --short)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml uv.lock
           git diff --staged --quiet || git commit -m "chore: update $OLD to $NEW"
           git push


### PR DESCRIPTION
## Related ticket

N/A (follow-up: allow bump workflow to push to branches with "Require signed commits")

## Description

- Add GPG commit signing in `bump-version.yml` via `crazy-max/ghaction-import-gpg@v6` so bump commits are verified and branch protection "Require signed commits" can stay enabled.
- Use repository **variables** `COMMITTER_NAME` and `COMMITTER_EMAIL` (instead of secrets) for the commit author; they must match the GitHub account that has the GPG key.
- Document required secrets (PAT_ADMIN, GPG_PRIVATE_KEY, optional GPG_PASSPHRASE) and variables in the workflow header.

## Documentation and additional notes

- Add repo variables: `COMMITTER_NAME`, `COMMITTER_EMAIL`.
- Add secret `GPG_PRIVATE_KEY` (ASCII-armored private key). Add `GPG_PASSPHRASE` only if the key has a passphrase (do not create it with an empty value).

Made with [Cursor](https://cursor.com)