### PR TITLE
docs: translate README to English (fix #140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Python / NLTK
 
-Le projet utilise NLTK. Les données nécessaires (ex. `wordnet`) sont téléchargées automatiquement au premier `import pfmg`. Pour les installer à la main ou en CI :
+The project uses NLTK. Required data (e.g. `wordnet`) is downloaded automatically on first `import pfmg`. To install it manually or in CI:
 
 ```bash
 python -m nltk.downloader wordnet
@@ -10,12 +10,12 @@ python -m nltk.downloader wordnet
 
 ## CUE
 
-Pour installer CUE : télécharger le binaire ici : <https://github.com/cue-lang/cue/releases/download/v0.6.0/cue_v0.6.0_linux_amd64.tar.gz>
+To install CUE: download the binary from <https://github.com/cue-lang/cue/releases/download/v0.6.0/cue_v0.6.0_linux_amd64.tar.gz>
 
-Cette instruction `sudo` placera le binaire dans les programmes exécutables en ligne de commande :
+This `sudo` command will place the binary in the command-line executables path:
 
 ```bash
-sudo cp <localisation_téléchargement>/cue_v0.6.0_linux_amd64/cue /usr/local/bin
+sudo cp <download_location>/cue_v0.6.0_linux_amd64/cue /usr/local/bin
 ```
 
-Teste en tapant simplement `cue` : si la commande apparaît, c’est bon.
+Test by typing `cue`: if the command is found, you are good to go.


### PR DESCRIPTION
## Related ticket

https://github.com/Krolov18/PFMG/issues/140

## Description

- Translate README.md from French to English (Python/NLTK section, CUE install instructions).
- Aligns with project convention: docstrings, comments, and docs in English.

## Documentation and additional notes

None.

Made with [Cursor](https://cursor.com)