### PR TITLE
ci: add Install uv step to bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Bump patch version (dev), regenerate lockfile, commit and push
         env:
           UV_SYSTEM_PYTHON: "1"
@@ -71,6 +73,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Bump minor version (dev → main), regenerate lockfile, commit and push
         env:
           UV_SYSTEM_PYTHON: "1"


### PR DESCRIPTION
## Related ticket

N/A (fixes `uv: command not found` in bump-patch-on-dev / bump-minor-on-main)

## Description

- Add "Install uv" step in both jobs of `bump-version.yml` (after setup-python, before the bump script).
- `uv version --bump` requires `uv` to be installed; the curl install places it in `$HOME/.local/bin`, already prepended in the script PATH.

## Documentation and additional notes

None.

Made with [Cursor](https://cursor.com)