### PR TITLE
fix(#152): trigger Release PR workflow on push to dev

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,9 +1,12 @@
-# Create or reuse a PR dev → main for release. Trigger manually from the Actions tab.
+# Create or reuse a PR dev → main for release.
+# Runs on every push to dev (or manually via workflow_dispatch).
 # Merge is done manually (and can be protected by required reviewers on main).
 
 name: Release PR (dev → main)
 
 on:
+  push:
+    branches: [dev]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Related ticket

https://github.com/Krolov18/PFMG/issues/152

## Description

Add `push: branches: [dev]` to the Release PR workflow so it runs on every push to `dev` and creates or reuses the dev → main PR. Manual trigger (workflow_dispatch) is unchanged.

## Documentation and additional notes

None.

Made with [Cursor](https://cursor.com)