### PR TITLE
feat(#155): enable Renovate and retire Dependabot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate config for PFMG (Python/uv)",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["pep621", "uv"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "lockFileMaintenanceBranchName": "renovate/uv-lockfile-maintenance"
+  },
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group minor and patch Python dependency updates",
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python dependencies (non-major)"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Enable Renovate for Python/uv (pyproject.toml + uv.lock)
- Plan to retire Dependabot in favor of Renovate for dependency updates

## Details

- Add .github/renovate.json with , managers  and , and weekly schedule
- Configure lockfile maintenance branch for uv.lock
- Disabling Dependabot will be done via repository security settings (Code security and analysis) once Renovate is in place

Closes #155.

Made with [Cursor](https://cursor.com)