### PR TITLE
feat(#158): add merge drivers for uv.lock and pyproject.toml (dev→main)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Merge drivers: keep current branch version for lockfile and project.version on dev>main merges
+uv.lock merge=ourslock
+pyproject.toml merge=pyprojectversion

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -25,6 +25,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT_ADMIN }}
+      - name: Configure git merge drivers
+        run: |
+          set -e
+          ROOT="${GITHUB_WORKSPACE}"
+          git config merge.ourslock.driver true
+          git config merge.pyprojectversion.driver "python3 $ROOT/scripts/merge-drivers/pyproject_version.py %O %A %B %P"
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:
@@ -61,6 +67,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT_ADMIN }}
+      - name: Configure git merge drivers
+        run: |
+          set -e
+          ROOT="${GITHUB_WORKSPACE}"
+          git config merge.ourslock.driver true
+          git config merge.pyprojectversion.driver "python3 $ROOT/scripts/merge-drivers/pyproject_version.py %O %A %B %P"
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Configure git merge drivers
+        run: |
+          set -e
+          ROOT="${GITHUB_WORKSPACE}"
+          git config merge.ourslock.driver true
+          git config merge.pyprojectversion.driver "python3 $ROOT/scripts/merge-drivers/pyproject_version.py %O %A %B %P"
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"

--- a/scripts/merge-drivers/README.md
+++ b/scripts/merge-drivers/README.md
@@ -1,0 +1,34 @@
+# Merge drivers
+
+Custom merge behaviour for `dev` → `main` merges where version bumps differ (patch on dev, minor on main).
+
+| File             | Driver             | Behaviour |
+|------------------|--------------------|-----------|
+| `uv.lock`        | `ourslock`         | Always keep **current** (ours) version. No conflict. |
+| `pyproject.toml` | `pyprojectversion` | Keep **current** for `[project]` `version`; other conflicts stay as markers. |
+
+## Setup (once per clone)
+
+From the repo root:
+
+```bash
+./scripts/merge-drivers/setup.sh
+```
+
+Or manually:
+
+```bash
+git config merge.ourslock.driver true
+git config merge.pyprojectversion.driver "python3 $(git rev-parse --show-toplevel)/scripts/merge-drivers/pyproject_version.py %O %A %B %P"
+```
+
+## Testing
+
+From the repo root, after configuring the drivers:
+
+```bash
+./scripts/merge-drivers/setup.sh
+./scripts/merge-drivers/test-merge-drivers.sh
+```
+
+The test creates temporary branches `test-merge-main` and `test-merge-dev` with different versions and lockfile content, merges dev into main, then checks that `pyproject.toml` version and `uv.lock` are the "ours" (main) version. Branches are deleted unless you pass `--no-cleanup`.

--- a/scripts/merge-drivers/pyproject_version.py
+++ b/scripts/merge-drivers/pyproject_version.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Merge driver for pyproject.toml.
+
+- Keeps the current branch's (ours) value for [project] version.
+- Runs a normal 3-way merge for the rest; other conflicts are left as markers.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def extract_project_version(content: str) -> str | None:
+    """Extract the version value from the first [project] section."""
+    in_project = False
+    for line in content.splitlines():
+        line_stripped = line.strip()
+        if line_stripped == "[project]":
+            in_project = True
+            continue
+        if in_project and line_stripped.startswith("["):
+            break
+        if in_project:
+            m = re.match(r"version\s*=\s*[\"']([^\"']+)[\"']", line_stripped)
+            if m:
+                return m.group(1)
+    return None
+
+
+def replace_project_version_in_merged(merged: str, our_version: str) -> str:
+    """Replace [project] version with our_version in merged content.
+
+    Resolves conflict blocks that only concern the version line; leaves other
+    conflict markers unchanged.
+    """
+    lines = merged.splitlines(keepends=True)
+    result: list[str] = []
+    i = 0
+    in_project = False
+    version_key_re = re.compile(r"^\s*version\s*=")
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if stripped == "[project]":
+            in_project = True
+            result.append(line)
+            i += 1
+            continue
+
+        if in_project and stripped.startswith("[") and stripped != "[project]":
+            in_project = False
+
+        # Conflict block that might contain version
+        if in_project and stripped.startswith("<<<<<<<"):
+            block: list[str] = [line]
+            i += 1
+            has_version = False
+            while i < len(lines) and not lines[i].strip().startswith(">>>>>>>"):
+                if version_key_re.match(lines[i]):
+                    has_version = True
+                block.append(lines[i])
+                i += 1
+            if i < len(lines):
+                block.append(lines[i])
+                i += 1
+            if has_version:
+                result.append(f'version = "{our_version}"\n')
+            else:
+                result.extend(block)
+            continue
+
+        # Single version line (no conflict)
+        if in_project and version_key_re.match(line):
+            result.append(f'version = "{our_version}"\n')
+            i += 1
+            continue
+
+        result.append(line)
+        i += 1
+
+    return "".join(result)
+
+
+def main() -> int:
+    """Run merge driver: keep ours for [project] version, merge rest."""
+    if len(sys.argv) != 5:
+        sys.stderr.write("Usage: pyproject_version.py <base> <ours> <theirs> <path>\n")
+        return 2
+    base_path, ours_path, theirs_path, _path = sys.argv[1:5]
+
+    ours_content = Path(ours_path).read_text()
+    our_version = extract_project_version(ours_content)
+    if our_version is None:
+        sys.stderr.write("Merge driver: no [project] version in ours, aborting.\n")
+        return 1
+
+    # Paths come from git merge driver (trusted).
+    git_cmd = shutil.which("git") or "git"
+    result = subprocess.run(  # noqa: S603
+        [git_cmd, "merge-file", "-p", ours_path, base_path, theirs_path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    merged_content = result.stdout
+
+    resolved = replace_project_version_in_merged(merged_content, our_version)
+    Path(ours_path).write_text(resolved)
+
+    # 0 = no conflict, 1 = conflicts (we resolved version; others may remain in file)
+    return 0 if result.returncode in (0, 1) else result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/merge-drivers/setup.sh
+++ b/scripts/merge-drivers/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Configure merge drivers for this repo (run once per clone).
+# See .gitattributes and scripts/merge-drivers/README.md.
+set -e
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+git config merge.ourslock.driver true
+git config merge.pyprojectversion.driver "python3 $ROOT/scripts/merge-drivers/pyproject_version.py %O %A %B %P"
+echo "Merge drivers configured: ourslock (uv.lock), pyprojectversion (pyproject.toml)"

--- a/scripts/merge-drivers/test-merge-drivers.sh
+++ b/scripts/merge-drivers/test-merge-drivers.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Test merge drivers: simulate dev → main merge with different versions.
+# Run from repo root. Uses temporary branches; leaves repo on original branch.
+# Requires: merge drivers already configured (./scripts/merge-drivers/setup.sh).
+set -e
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+START_BRANCH="$(git branch --show-current)"
+CLEANUP=1
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-cleanup) CLEANUP=0; shift ;;
+    *) echo "Usage: $0 [--no-cleanup]"; exit 1 ;;
+  esac
+done
+
+echo "=== Merge driver test (dev → main simulation) ==="
+echo "Start branch: $START_BRANCH"
+
+# Ensure merge drivers are configured
+git config merge.ourslock.driver >/dev/null 2>&1 || { echo "Run ./scripts/merge-drivers/setup.sh first."; exit 1; }
+git config merge.pyprojectversion.driver >/dev/null 2>&1 || { echo "Run ./scripts/merge-drivers/setup.sh first."; exit 1; }
+
+# Create temp branches from current HEAD (common base)
+git branch -D test-merge-main 2>/dev/null || true
+git branch -D test-merge-dev  2>/dev/null || true
+git branch test-merge-main
+git branch test-merge-dev
+
+# "main": version 2.0.0
+git checkout test-merge-main
+sed -i 's/^version = ".*"/version = "2.0.0"/' pyproject.toml
+git add pyproject.toml uv.lock
+git commit -m "test: main at 2.0.0" --no-gpg-sign 2>/dev/null || git commit -m "test: main at 2.0.0"
+MAIN_LOCK_HASH=$(git show test-merge-main:uv.lock | md5sum)
+
+# "dev": version 2.0.1 (patch bump) + change lockfile so it differs
+git checkout test-merge-dev
+sed -i 's/^version = ".*"/version = "2.0.1"/' pyproject.toml
+# Ensure lockfile differs (append newline on dev so merge has two different contents)
+printf '\n' >> uv.lock
+git add pyproject.toml uv.lock
+git commit -m "test: dev at 2.0.1" --no-gpg-sign 2>/dev/null || git commit -m "test: dev at 2.0.1"
+
+# Merge dev into main (ours = main; we want to keep main's version and lockfile)
+git checkout test-merge-main
+echo "--- Merging test-merge-dev into test-merge-main ---"
+if ! git merge test-merge-dev -m "test: merge dev into main" --no-gpg-sign 2>/dev/null; then
+  git merge test-merge-dev -m "test: merge dev into main"
+fi
+
+# Checks
+FAIL=0
+echo ""
+echo "--- Checks ---"
+VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+if [ "$VERSION" = "2.0.0" ]; then
+  echo "  pyproject.toml version: $VERSION (expected 2.0.0, ours kept) OK"
+else
+  echo "  pyproject.toml version: $VERSION (expected 2.0.0) FAIL"
+  FAIL=1
+fi
+CURRENT_LOCK_HASH=$(cat uv.lock | md5sum)
+if [ "$CURRENT_LOCK_HASH" = "$MAIN_LOCK_HASH" ]; then
+  echo "  uv.lock: matches main (ours) OK"
+else
+  echo "  uv.lock: content differs from main (driver should keep ours) FAIL"
+  FAIL=1
+fi
+if grep -q "<<<<<<< " pyproject.toml 2>/dev/null; then
+  echo "  pyproject.toml: conflict markers still present (resolve if not version-only)"
+fi
+
+if [ "$CLEANUP" -eq 1 ]; then
+  git checkout "$START_BRANCH"
+  git branch -D test-merge-main test-merge-dev
+  echo ""
+  echo "Cleaned up test branches."
+fi
+echo ""
+[ "$FAIL" -eq 0 ] && echo "All checks passed." || { echo "Some checks failed."; exit 1; }


### PR DESCRIPTION
## Related ticket

#158

## Description

- **Merge drivers**: `.gitattributes` assigns `uv.lock` → `ourslock` (always keep current branch) and `pyproject.toml` → `pyprojectversion` (keep current for `[project] version`, leave other conflicts as markers).
- **Scripts**: `scripts/merge-drivers/pyproject_version.py`, `setup.sh`, `test-merge-drivers.sh`, and README.
- **CI**: `ci.yml` and `bump-version.yml` configure the same merge drivers in GitHub Actions so merges in workflows use the same behaviour.

## Documentation and additional notes

- `scripts/merge-drivers/README.md`: setup and testing. Run `./scripts/merge-drivers/setup.sh` once per clone, then `./scripts/merge-drivers/test-merge-drivers.sh` to verify.

Made with [Cursor](https://cursor.com)