### PR TITLE
feat(#165): add merge-release workflow, drop merge driver config from ci/bump-version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -28,12 +28,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT_ADMIN }}
-      - name: Configure git merge drivers
-        run: |
-          set -e
-          ROOT="${GITHUB_WORKSPACE}"
-          git config merge.ourslock.driver true
-          git config merge.pyprojectversion.driver "python3 $ROOT/scripts/merge-drivers/pyproject_version.py %O %A %B %P"
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:
@@ -70,12 +64,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT_ADMIN }}
-      - name: Configure git merge drivers
-        run: |
-          set -e
-          ROOT="${GITHUB_WORKSPACE}"
-          git config merge.ourslock.driver true
-          git config merge.pyprojectversion.driver "python3 $ROOT/scripts/merge-drivers/pyproject_version.py %O %A %B %P"
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Configure git merge drivers
-        run: |
-          set -e
-          ROOT="${GITHUB_WORKSPACE}"
-          git config merge.ourslock.driver true
-          git config merge.pyprojectversion.driver "python3 $ROOT/scripts/merge-drivers/pyproject_version.py %O %A %B %P"
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -1,0 +1,70 @@
+# Merge dev into main using the repo's merge drivers (keep main's version and uv.lock).
+# Run manually from the Actions tab when the release PR has conflicts or you want to avoid merging via the GitHub UI.
+# Uses the same PAT and GPG setup as bump-version; closes the release PR after pushing.
+
+name: Merge release (dev → main)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+    branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  merge-release:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'release-merge')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_ADMIN }}
+
+      - name: Configure git merge drivers
+        run: |
+          set -e
+          ROOT="${GITHUB_WORKSPACE}"
+          git config merge.ourslock.driver true
+          git config merge.pyprojectversion.driver "python3 $ROOT/scripts/merge-drivers/pyproject_version.py %O %A %B %P"
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_committer_name: ${{ vars.COMMITTER_NAME }}
+          git_committer_email: ${{ vars.COMMITTER_EMAIL }}
+
+      - name: Merge dev into main and push
+        env:
+          GH_TOKEN: ${{ secrets.PAT_ADMIN }}
+        run: |
+          set -e
+          git fetch origin main dev
+          git checkout -B main origin/main
+          git merge origin/dev -m "Release: merge dev into main"
+          git push origin main
+
+      - name: Close release PR
+        env:
+          GH_TOKEN: ${{ secrets.PAT_ADMIN }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR="${{ github.event.pull_request.number }}"
+          else
+            PR=$(gh pr list --base main --head dev --state open --json number -q '.[0].number' 2>/dev/null || true)
+          fi
+          if [ -n "$PR" ]; then
+            gh pr close "$PR" --comment "Merged via **Merge release (dev → main)** workflow. Merge drivers kept main's version and \`uv.lock\`."
+          fi


### PR DESCRIPTION
## Related ticket

#165

## Description

- Add `.github/workflows/merge-release.yml`: run manually (workflow_dispatch) or by adding label `release-merge` on the release PR; merges dev into main using the repo merge drivers, pushes to main, closes the release PR.
- Remove the "Configure git merge drivers" steps from `ci.yml` and `bump-version.yml` (no merge happens there, so the config was unused).

## Documentation and additional notes

None.

Made with [Cursor](https://cursor.com)