### PR TITLE
Release workflow: bump only on merge-release, sync dev from main

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,11 +1,6 @@
-# Bump version and regenerate lockfile on push to dev (patch) or main (minor).
-# Skips when the head commit message starts with "chore: update" to avoid loops.
-#
-# For protected branches (dev/main):
-# - PAT_ADMIN: Personal Access Token of a user with admin rights (to bypass "Require PR").
-# - GPG_PRIVATE_KEY: ASCII-armored GPG private key (gpg --armor --export-secret-keys KEY_ID).
-# - GPG_PASSPHRASE: Passphrase of the key. If the key has no passphrase, do not create this secret (GitHub rejects empty values).
-# - COMMITTER_NAME, COMMITTER_EMAIL: Repository variables; must match the GitHub account that has the GPG key (verified commits).
+# Version is bumped only in merge-release.yml when releasing (merge dev → main).
+# This workflow no longer auto-bumps on push to dev/main so dev and main stay in sync after each release.
+
 name: Bump version
 
 on:
@@ -19,74 +14,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  bump-patch-on-dev:
-    if: "github.ref == 'refs/heads/dev' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: update')"
+  # Disabled: version bump happens in Merge release (dev → main) workflow only.
+  bump-disabled:
+    if: false
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PAT_ADMIN }}
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_committer_name: ${{ vars.COMMITTER_NAME }}
-          git_committer_email: ${{ vars.COMMITTER_EMAIL }}
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - name: Bump patch version (dev), regenerate lockfile, commit and push
-        env:
-          UV_SYSTEM_PYTHON: "1"
-        run: |
-          set -e
-          export PATH="$HOME/.local/bin:$PATH"
-          OLD=$(uv version --short)
-          uv version --bump patch
-          NEW=$(uv version --short)
-          git add pyproject.toml uv.lock
-          git diff --staged --quiet || git commit -m "chore: update $OLD to $NEW"
-          git push
-
-  bump-minor-on-main:
-    if: "github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: update')"
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PAT_ADMIN }}
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_committer_name: ${{ vars.COMMITTER_NAME }}
-          git_committer_email: ${{ vars.COMMITTER_EMAIL }}
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - name: Bump minor version (dev → main), regenerate lockfile, commit and push
-        env:
-          UV_SYSTEM_PYTHON: "1"
-        run: |
-          set -e
-          export PATH="$HOME/.local/bin:$PATH"
-          OLD=$(uv version --short)
-          uv version --bump minor
-          NEW=$(uv version --short)
-          git add pyproject.toml uv.lock
-          git diff --staged --quiet || git commit -m "chore: update $OLD to $NEW"
-          git push
+      - run: echo "Use the Merge release workflow to release and bump version."

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -1,6 +1,6 @@
-# Merge dev into main using the repo's merge drivers (keep main's version and uv.lock).
-# Run manually from the Actions tab when the release PR has conflicts or you want to avoid merging via the GitHub UI.
-# Uses the same PAT and GPG setup as bump-version; closes the release PR after pushing.
+# Release = merge dev → main (with merge drivers) + bump minor on main + sync dev from main.
+# Run manually (workflow_dispatch) or add label "release-merge" on the release PR.
+# Version is bumped only here; bump-version.yml no longer auto-bumps on push.
 
 name: Merge release (dev → main)
 
@@ -56,6 +56,39 @@ jobs:
           git merge origin/dev -m "Release: merge dev into main"
           git push origin main
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Bump minor version on main and push
+        env:
+          GH_TOKEN: ${{ secrets.PAT_ADMIN }}
+          UV_SYSTEM_PYTHON: "1"
+        run: |
+          set -e
+          export PATH="$HOME/.local/bin:$PATH"
+          git fetch origin main
+          git checkout -B main origin/main
+          OLD=$(uv version --short)
+          uv version --bump minor
+          NEW=$(uv version --short)
+          git add pyproject.toml uv.lock
+          git diff --staged --quiet || git commit -m "chore: update $OLD to $NEW"
+          git push origin main
+
+      - name: Sync dev from main and push
+        env:
+          GH_TOKEN: ${{ secrets.PAT_ADMIN }}
+        run: |
+          set -e
+          git fetch origin main dev
+          git checkout -B dev origin/dev
+          git merge origin/main -m "Sync dev with main after release"
+          git push origin dev
+
       - name: Close release PR
         env:
           GH_TOKEN: ${{ secrets.PAT_ADMIN }}
@@ -66,5 +99,5 @@ jobs:
             PR=$(gh pr list --base main --head dev --state open --json number -q '.[0].number' 2>/dev/null || true)
           fi
           if [ -n "$PR" ]; then
-            gh pr close "$PR" --comment "Merged via **Merge release (dev → main)** workflow. Merge drivers kept main's version and \`uv.lock\`."
+            gh pr close "$PR" --comment "Merged via **Merge release (dev → main)** workflow. Merge drivers applied; version bumped on main; dev synced from main."
           fi


### PR DESCRIPTION
## Related ticket
Closes #168

## Description
- **merge-release.yml**: After merging dev → main, bump minor on main and push; then merge main into dev and push so dev and main stay in sync.
- **bump-version.yml**: Disable auto-bump on push to dev/main; version is bumped only when running the Merge release workflow.

## Documentation and additional notes
- Single source of version; no more diverging dev/main versions.

Made with [Cursor](https://cursor.com)