### PR TITLE
ci(#197): skip ty when no Python files changed in PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           if [ -s changed_py.txt ]; then
             uv run ty check $(cat changed_py.txt)
           else
-            uv run ty check
+            echo "No Python files changed, skipping type checker."
           fi
       - name: Test with pytest
         run: |


### PR DESCRIPTION
## Objective
Avoid full-project `ty check` when a PR does not modify any `.py` file (e.g. Renovate or workflow-only PRs).

Related to #197

## Changes
- `.github/workflows/ci.yml`: if `changed_py.txt` is empty, skip type checker (same idea as the linter step).

## Testing
- N/A (YAML only)

## Footer

Closes #197

Made with [Cursor](https://cursor.com)