### PR TITLE
ci(#203): sync dev from main on push to main

### DIFF
--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -1,4 +1,5 @@
-# Release = merge dev → main (with merge drivers) + bump minor on main + sync dev from main.
+# Release = merge dev → main (with merge drivers) + bump minor on main.
+# Dev is synced from main by sync-dev-from-main.yml on every push to main.
 # Run manually (workflow_dispatch) or add label "release-merge" on the release PR.
 # Version is bumped only here; bump-version.yml no longer auto-bumps on push.
 
@@ -78,16 +79,6 @@ jobs:
           git add pyproject.toml uv.lock
           git diff --staged --quiet || git commit -m "chore: update $OLD to $NEW"
           git push origin main
-
-      - name: Sync dev from main and push
-        env:
-          GH_TOKEN: ${{ secrets.PAT_ADMIN }}
-        run: |
-          set -e
-          git fetch origin main dev
-          git checkout -B dev origin/dev
-          git merge origin/main -m "Sync dev with main after release"
-          git push origin dev
 
       - name: Close release PR
         env:

--- a/.github/workflows/sync-dev-from-main.yml
+++ b/.github/workflows/sync-dev-from-main.yml
@@ -1,0 +1,49 @@
+# After every update to main (including manual merge of the release PR), merge main into dev
+# so dev contains the full history of main (release merge commits, version bumps, etc.).
+# Complements merge-release.yml, which also syncs dev when that workflow runs to completion.
+
+name: Sync dev from main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-dev-from-main
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  sync-dev:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_ADMIN }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_committer_name: ${{ vars.COMMITTER_NAME }}
+          git_committer_email: ${{ vars.COMMITTER_EMAIL }}
+
+      - name: Merge main into dev and push
+        env:
+          GH_TOKEN: ${{ secrets.PAT_ADMIN }}
+        run: |
+          set -e
+          git fetch origin main dev
+          git checkout -B dev origin/dev
+          git merge origin/main -m "Sync dev with main after release"
+          git push origin dev


### PR DESCRIPTION
## Objective
Automate merging `main` into `dev` whenever `main` is updated (manual release PR merge or merge-release pushes), so `dev` always contains `main` history.

Related to #203

## Changes
- New `sync-dev-from-main.yml`: on `push` to `main` + `workflow_dispatch`; GPG-signed merge; `PAT_ADMIN`; concurrency group
- `merge-release.yml`: remove inline sync step (redundant with push-triggered sync); update header comment

## Testing
- YAML only; validate in Actions after merge

## Footer

Closes #203

Made with [Cursor](https://cursor.com)